### PR TITLE
build(gradle): add mixinextras-common for Forge to fix compilation errors

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -61,9 +61,9 @@ dependencies {
 
 	// dependencies
 //	include(modImplementation("me.fallenbreath:conditional-mixin-${mod_brand}:${project.conditionalmixin_version}"))
-//  if (mod_brand == 'forge') {
-//      compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:${project.mixinextras_version}"))
-//  }
+//    if (mod_brand == 'forge') {
+//        compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:${project.mixinextras_version}"))
+//    }
 //	include(annotationProcessor(implementation("io.github.llamalad7:mixinextras-${mod_brand}:${project.mixinextras_version}")))
 }
 

--- a/common.gradle
+++ b/common.gradle
@@ -61,6 +61,9 @@ dependencies {
 
 	// dependencies
 //	include(modImplementation("me.fallenbreath:conditional-mixin-${mod_brand}:${project.conditionalmixin_version}"))
+//  if (mod_brand == 'forge') {
+//      compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:${project.mixinextras_version}"))
+//  }
 //	include(annotationProcessor(implementation("io.github.llamalad7:mixinextras-${mod_brand}:${project.mixinextras_version}")))
 }
 

--- a/common.gradle
+++ b/common.gradle
@@ -61,9 +61,9 @@ dependencies {
 
 	// dependencies
 //	include(modImplementation("me.fallenbreath:conditional-mixin-${mod_brand}:${project.conditionalmixin_version}"))
-//    if (mod_brand == 'forge') {
-//        compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:${project.mixinextras_version}"))
-//    }
+//	if (mod_brand == 'forge') {
+//		compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:${project.mixinextras_version}"))
+//	}
 //	include(annotationProcessor(implementation("io.github.llamalad7:mixinextras-${mod_brand}:${project.mixinextras_version}")))
 }
 


### PR DESCRIPTION
修复forge版本mixinextras的编译问题
forge版本中，目录结构是以下形式，会导致编译时找不到类，所以要添加mixinextras-common
<img width="383" height="289" alt="image" src="https://github.com/user-attachments/assets/b9d3b97c-f563-4bfb-b0af-196c8ea456b4" />

请见：https://github.com/LlamaLad7/MixinExtras/blob/master/README.MD