### PR TITLE
fix: add optional clientMixinAudit config (commented)

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -105,6 +105,11 @@ loom {
 //			vmArgs auditVmArgs
 //			ideConfigGenerated false
 //		}
+//		clientMixinAudit {
+//			client()
+//			vmArgs auditVmArgs
+//			ideConfigGenerated false
+//		}
 //	}
 }
 


### PR DESCRIPTION
Reference: https://github.com/TISUnion/Carpet-TIS-Addition/blob/master/common.gradle

This adds the commented clientMixinAudit block to `common.gradle`.

Without these lines, the GitHub Actions workflow will fail when the publish step is enabled (uncommented):
https://github.com/Fallen-Breath/fabric-mod-template/blob/master/.github/workflows/build.yml

Steps to reproduce:

1. Uncomment the publish step under `[FEATURE] MIXIN_AUDITOR` in build.yml
2. Run the workflow
3. The build fails due to missing clientMixinAudit task configuration

Fix:

- Add the commented clientMixinAudit block so users can opt-in safely.